### PR TITLE
Add Workflow to Run Coding Metrics

### DIFF
--- a/.github/workflows/coding-metrics.yml
+++ b/.github/workflows/coding-metrics.yml
@@ -1,0 +1,25 @@
+name: "Coding Metrics"
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  coding-metrics:
+    name: Coding Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coding Metrics
+        uses: JackPlowman/coding-metrics@f8e1690e0517de742b2c5a161f9c18b863996ba0
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          debug: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new GitHub Actions workflow to automate the collection of coding metrics. The workflow is triggered on pushes to the `main` branch and runs on a daily schedule. It uses the `JackPlowman/coding-metrics` action to gather metrics and is configured with the necessary permissions and environment variables.

**Automation and workflow setup:**

* Added `.github/workflows/coding-metrics.yml` to define a new workflow for coding metrics, triggered on pushes to `main` and on a daily schedule.
* Integrated the `JackPlowman/coding-metrics` GitHub Action to collect coding metrics, with configuration for authentication and debugging.