### PR TITLE
Update Security Links

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability within this project, please report it t
 
 To report a vulnerability:
 
-1. Go to the [Security tab](https://github.com/JackPlowman/repository-template/security) of the repository.
+1. Go to the [Security tab](https://github.com/JackPlowman/test-coding-metrics/security) of the repository.
 2. Click on "Report a vulnerability".
 3. Follow the instructions to provide details about the vulnerability.
 
@@ -20,6 +20,6 @@ We release patches for security vulnerabilities in the following versions:
 
 ## Security Updates
 
-We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/repository-template/security/advisories) section.
+We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/test-coding-metrics/security/advisories) section.
 
 Thank you for helping to keep this project secure.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the security documentation to reference the correct GitHub repository. These changes ensure that users are directed to the appropriate location for reporting vulnerabilities and viewing security advisories.

Documentation updates:

* Updated the link in the SECURITY.md instructions to point to the `test-coding-metrics` repository's Security tab.
* Updated the link for Security Advisories to reference the `test-coding-metrics` repository.