### PR TITLE
Remove SuperLinter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
           - "*"
         exclude-patterns:
           - "JackPlowman/coding-metrics"
-          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"

--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -12,11 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/other-configurations/*",
-                ".github/super-linter-configurations/*",
-              ]
+          - any-glob-to-any-file: [".github/other-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,28 +16,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  check-code-quality:
-    name: Check Code Quality
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Lint Code Base
-        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINTER_RULES_PATH: .github/super-linter-configurations
-          YAML_ERROR_ON_WARNING: true
-          VALIDATE_GIT_COMMITLINT: false
-          VALIDATE_EDITORCONFIG: false
-
   common-code-checks:
     name: Common Code Checks
     permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request primarily removes the use of the Super Linter tool from the repository's configuration and automation. The changes focus on cleaning up related configuration files and workflow definitions to reflect this removal.

**Super Linter removal:**

* Deleted the entire `check-code-quality` job from the `.github/workflows/code-checks.yml` workflow, which previously used Super Linter for code quality checks.
* Removed the exclusion of the `super-linter/super-linter` pattern from the Dependabot configuration in `.github/dependabot.yml`, as Super Linter is no longer used.
* Updated the labeller configuration in `.github/other-configurations/labeller.yml` to remove references to `.github/super-linter-configurations`, since the directory is no longer relevant.