### PR TITLE
Set Coding Metrics Permissions

### DIFF
--- a/.github/workflows/coding-metrics.yml
+++ b/.github/workflows/coding-metrics.yml
@@ -6,17 +6,14 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions:
-  contents: read
-  packages: read
-
-env:
-  FORCE_COLOR: 1
+permissions: {}
 
 jobs:
   coding-metrics:
     name: Coding Metrics
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Coding Metrics
         uses: JackPlowman/coding-metrics@373e7ab040e73a7131c43964d0e9a46b32239d8d


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow configuration for coding metrics. The main change is an adjustment to workflow permissions to ensure the job has the necessary access to write contents, which is required for its operation.

Workflow permissions update:

* [`.github/workflows/coding-metrics.yml`](diffhunk://#diff-6c07998d92ff9275aef3a8510ed4b7a276f2dfc370668025311a4041add7e91cL9-R16): Changed the global `permissions` to an empty object and moved permissions configuration into the `coding-metrics` job, granting `contents: write` to allow the job to write repository contents.