### PR TITLE
Update License to Licence

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -21,7 +21,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small correction to the file pattern used for labeling markdown files. The change updates the spelling of the license file from `LICENSE` to `LICENCE` in the `.github/tool-configurations/labeller.yml` configuration.